### PR TITLE
Fix `{insert,remove}_text` when `text` is `''`

### DIFF
--- a/.changeset/clever-needles-kiss.md
+++ b/.changeset/clever-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+Correctly handle `insert_text` and `remove_text` operations that insert or remove no text.

--- a/packages/core/src/applyToYjs/text/insertText.ts
+++ b/packages/core/src/applyToYjs/text/insertText.ts
@@ -20,6 +20,8 @@ export function insertText(
     throw new Error('Cannot insert text into non-text node');
   }
 
+  if (!op.text.length) return;
+
   if (isInsertDeltaEmptyText(targetDelta)) {
     target.delete(textRange.start, targetDelta[0].insert.length);
   }

--- a/packages/core/src/applyToYjs/text/removeText.ts
+++ b/packages/core/src/applyToYjs/text/removeText.ts
@@ -11,6 +11,7 @@ export function removeText(
 ): void {
   const { path, offset, text } = op;
   const { length } = text;
+  if (!length) return;
 
   const {
     yParent: target,

--- a/packages/core/test/collaboration/insertText/empty.tsx
+++ b/packages/core/test/collaboration/insertText/empty.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export function run(editor: Editor) {
+  editor.apply({
+    type: 'insert_text',
+    path: [0, 0],
+    offset: 0,
+    text: '',
+  });
+}

--- a/packages/core/test/collaboration/removeText/empty.tsx
+++ b/packages/core/test/collaboration/removeText/empty.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <text>test</text>
+    </unstyled>
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text>test</text>
+    </unstyled>
+  </editor>
+);
+
+export function run(editor: Editor) {
+  Editor.withoutNormalizing(editor, () => {
+    editor.apply({
+      type: 'split_node',
+      path: [0, 0],
+      position: 0,
+      properties: {},
+    });
+
+    editor.apply({
+      type: 'remove_text',
+      path: [0, 0],
+      offset: 0,
+      text: '',
+    });
+  });
+}


### PR DESCRIPTION
The `insert_text` and `remove_text` operations previously assumed that at least one character of text would be inserted or removed, and behaved incorrectly with regard to empty text characters if this was not the case. This PR resolves this issue.