### PR TITLE
Fix delta sort logic

### DIFF
--- a/.changeset/thick-moose-pump.md
+++ b/.changeset/thick-moose-pump.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+Fix a bug that occurs on Chromium and WebKit due to the implementation of those browsers' `Array.prototype.sort` functions differing from those of Firefox and Node. This resulted in inconsistent behaviour when sorting Yjs deltas using a compare function that did not obey the transitive property, causing deltas to be applied incorrectly in some cases.

--- a/packages/core/src/applyToSlate/textEvent.ts
+++ b/packages/core/src/applyToSlate/textEvent.ts
@@ -5,7 +5,7 @@ import { deltaInsertToSlateNode } from '../utils/convert';
 import { getSlatePath } from '../utils/location';
 import { omitEmptyTextAttribute } from '../utils/emptyText';
 import { ClonedSharedRoot } from '../utils/ClonedSharedRoot';
-import { getChangeType, yTextToInsertDelta } from '../utils/delta';
+import { sortDelta, yTextToInsertDelta } from '../utils/delta';
 import { getSlateTargetsInRange } from './getSlateTargetsInRange';
 import { getInsertMethod } from './getInsertMethod';
 
@@ -40,25 +40,17 @@ function applyDelta(
       )
     ).reverse();
 
-  const sortedReversedDelta = delta
-    .slice()
-    /**
-     * If the last child of a node is removed before a new node is inserted to
-     * replace it, this can result in the Slate selection being placed at the
-     * end of the previous text node instead of remaining in the current
-     * node. To avoid this, flip the order of insertions and deletions so that
-     * insertions are always performed first, while preserving the order of non-
-     * insert/delete pairs.
-     */
-    .sort((a, b) => {
-      const aType = getChangeType(a);
-      const bType = getChangeType(b);
-      if (aType === 'insert' && bType === 'delete') return 1;
-      if (aType === 'delete' && bType === 'insert') return -1;
-      return 0;
-    })
-    // Apply changes in reverse order to avoid path changes
-    .reverse();
+  /**
+   * If the last child of a node is removed before a new node is inserted to
+   * replace it, this can result in the Slate selection being placed at the end
+   * of the previous text node instead of remaining in the current node. To
+   * avoid this, flip the order of insertions and deletions so that insertions
+   * are always performed first, while preserving the order of non-insert/delete
+   * pairs.
+   *
+   * Apply changes in reverse order to avoid path changes.
+   */
+  const sortedReversedDelta = sortDelta(delta).reverse();
 
   sortedReversedDelta.forEach((change) => {
     if ('retain' in change) {

--- a/packages/core/src/model/types.ts
+++ b/packages/core/src/model/types.ts
@@ -1,7 +1,6 @@
 import type { Editor, Element, Node } from 'slate';
 import type * as Y from 'yjs';
 
-export type ChangeType = 'insert' | 'delete' | 'retain';
 export type DeltaAttributes = {
   retain: number;
   attributes: Record<string, unknown>;

--- a/packages/core/src/utils/delta.ts
+++ b/packages/core/src/utils/delta.ts
@@ -1,11 +1,35 @@
 import * as Y from 'yjs';
-import { ChangeType, Delta, DeltaInsert, InsertDelta } from '../model/types';
+import { Delta, DeltaDelete, DeltaInsert, InsertDelta } from '../model/types';
 import { deepEquals } from './object';
 
-export function getChangeType(delta: Delta[number]): ChangeType {
-  if ('insert' in delta) return 'insert';
-  if ('delete' in delta) return 'delete';
-  return 'retain';
+/**
+ * Reorder mixed runs of insertions and deletions to put the deletions first.
+ */
+export function sortDelta(delta: Delta) {
+  const sortedDelta: Delta = [];
+  let deletions: DeltaDelete[] = [];
+  let insertions: DeltaInsert[] = [];
+
+  function flush() {
+    sortedDelta.push(...deletions);
+    sortedDelta.push(...insertions);
+    deletions = [];
+    insertions = [];
+  }
+
+  for (const change of delta) {
+    if ('insert' in change) {
+      insertions.push(change);
+    } else if ('delete' in change) {
+      deletions.push(change);
+    } else {
+      flush();
+      sortedDelta.push(change);
+    }
+  }
+
+  flush();
+  return sortedDelta;
 }
 
 export function normalizeInsertDelta(delta: InsertDelta): InsertDelta {


### PR DESCRIPTION
Fix a bug that occurs on Chromium and WebKit due to the implementation of those browsers' `Array.prototype.sort` functions differing from those of Firefox and Node. This resulted in inconsistent behaviour when sorting Yjs deltas using a compare function that did not obey the transitive property, causing deltas to be applied incorrectly in some cases.