### PR TITLE
Export `inspectYText`

### DIFF
--- a/.changeset/honest-games-walk.md
+++ b/.changeset/honest-games-walk.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': minor
+---
+
+Export the `inspectYText` utility function (previously used only in testing code)

--- a/docs/api/slate-yjs-core/utils.md
+++ b/docs/api/slate-yjs-core/utils.md
@@ -24,6 +24,10 @@ Get a slate range for a relative range. Returns null if the anchor/focus or both
 
 Get a [relative position](https://docs.yjs.dev/api/relative-positions) for a slate point.
 
-**`relativePositionToSlatePoint( sharedRoot: Y.XmlText, slateRoot: Node, pos: Y.RelativePosition ): BasePoint | null`**
+**`relativePositionToSlatePoint(sharedRoot: Y.XmlText, slateRoot: Node, pos: Y.RelativePosition): BasePoint | null`**
 
 Get a slate point for a relative position. Returns null if the relative position isn't part of the document anymore.
+
+**`inspectYText(yText: Y.XmlText): RecursiveDeltaInsert`**
+
+Convert a Y.XmlText to a plain JS object for testing and debugging purposes. Some non-deterministic attributes are omitted or modified to ensure a consistent output in testing code.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-import { RelativeRange } from './model/types';
 import {
   CursorEditor,
   CursorState,
@@ -20,6 +19,7 @@ import {
   slatePointToRelativePosition,
   slateRangeToRelativeRange,
 } from './utils/position';
+import { inspectYText } from './utils/yjs';
 
 export {
   withYjs,
@@ -37,11 +37,13 @@ export {
   RemoteCursorChangeEventListener,
   CursorStateChangeEvent,
   // Utils
-  RelativeRange,
   yTextToSlateElement,
   slateNodesToInsertDelta,
   slateRangeToRelativeRange,
   relativeRangeToSlateRange,
   slatePointToRelativePosition,
   relativePositionToSlatePoint,
+  inspectYText,
 };
+
+export type * from './model/types';

--- a/packages/core/src/model/types.ts
+++ b/packages/core/src/model/types.ts
@@ -17,6 +17,11 @@ export type Delta = Array<
   DeltaRetain | DeltaDelete | DeltaInsert | DeltaAttributes
 >;
 
+export interface RecursiveDeltaInsert extends Omit<DeltaInsert, 'insert'> {
+  insert: string | RecursiveInsertDelta | RecursiveDeltaInsert;
+}
+export type RecursiveInsertDelta = Array<RecursiveDeltaInsert>;
+
 export type TextRange = { start: number; end: number };
 
 export type HistoryStackItem = {

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -1,0 +1,7 @@
+export const STORED_POSITION_PREFIX = '__slateYjsStoredPosition_';
+
+/**
+ * Represent empty text nodes using a character with a special attribute, since
+ * Yjs doesn't support storing attributes on empty insertions.
+ */
+export const EMPTY_TEXT_PREFIX = '__slateYjsEmptyText_';

--- a/packages/core/src/utils/emptyText.ts
+++ b/packages/core/src/utils/emptyText.ts
@@ -1,11 +1,7 @@
 import * as Y from 'yjs';
 import { DeltaInsert, InsertDelta } from '../model/types';
+import { EMPTY_TEXT_PREFIX } from './constants';
 
-/**
- * Represent empty text nodes using a character with a special attribute, since
- * Yjs doesn't support storing attributes on empty insertions.
- */
-export const EMPTY_TEXT_PREFIX = '__slateYjsEmptyText_';
 const EMPTY_TEXT_CHAR = '\u200b'; // zero-width space
 
 export function isEmptyTextAttribute(key: string) {

--- a/packages/core/src/utils/position.ts
+++ b/packages/core/src/utils/position.ts
@@ -4,8 +4,7 @@ import { InsertDelta, RelativeRange, TextRange } from '../model/types';
 import { getInsertDeltaLength, yTextToInsertDelta } from './delta';
 import { getSlatePath, getYTarget, yOffsetToSlateOffsets } from './location';
 import { assertDocumentAttachment } from './yjs';
-
-export const STORED_POSITION_PREFIX = '__slateYjsStoredPosition_';
+import { STORED_POSITION_PREFIX } from './constants';
 
 /**
  * Map from path string -> key -> absolute position.

--- a/packages/core/src/utils/yjs.ts
+++ b/packages/core/src/utils/yjs.ts
@@ -1,4 +1,8 @@
 import * as Y from 'yjs';
+import { RecursiveDeltaInsert } from '../model/types';
+import { yTextToInsertDelta } from './delta';
+import { isEmptyTextAttribute, hasEmptyTextAttribute } from './emptyText';
+import { EMPTY_TEXT_PREFIX, STORED_POSITION_PREFIX } from './constants';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function assertDocumentAttachment<T extends Y.AbstractType<any>>(
@@ -7,4 +11,38 @@ export function assertDocumentAttachment<T extends Y.AbstractType<any>>(
   if (!sharedType.doc) {
     throw new Error("shared type isn't attached to a document");
   }
+}
+
+/**
+ * Serialize a Y text to a plain object for debugging and testing purposes.
+ */
+export function inspectYText(yText: Y.XmlText): RecursiveDeltaInsert {
+  const delta = yTextToInsertDelta(yText);
+
+  const mappedDelta = delta.map(({ insert, attributes }) => {
+    if (typeof insert !== 'string') return inspectYText(insert);
+    if (!attributes) return { insert };
+
+    const filteredAttributes = Object.fromEntries(
+      Object.entries(attributes).filter(([key]) => !isEmptyTextAttribute(key))
+    );
+
+    // Do not include random empty text attribute IDs
+    if (hasEmptyTextAttribute(attributes)) {
+      filteredAttributes[`${EMPTY_TEXT_PREFIX}<id>`] = true;
+    }
+
+    return { insert, attributes: filteredAttributes };
+  });
+
+  const attributes = yText.getAttributes();
+
+  // Do not include stored position attributes
+  const filteredAttributes = Object.fromEntries(
+    Object.entries(attributes).filter(
+      ([key]) => !key.startsWith(STORED_POSITION_PREFIX)
+    )
+  );
+
+  return { attributes: filteredAttributes, insert: mappedDelta };
 }

--- a/packages/core/test/support/runCollaborationTests.ts
+++ b/packages/core/test/support/runCollaborationTests.ts
@@ -4,14 +4,14 @@ import * as Y from 'yjs';
 import { FixtureModule, fixtures } from './fixtures';
 import { yTextToSlateElement } from '../../src';
 import { withTestingElements } from './withTestingElements';
-import { inspectYText, YJS_VERSION, yTextFactory } from './utils';
+import { YJS_VERSION, yTextFactory } from './utils';
 import {
   getStoredPosition,
   relativePositionToSlatePoint,
   setStoredPosition,
   slatePointToRelativePosition,
 } from '../../src/utils/position';
-import { assertDocumentAttachment } from '../../src/utils/yjs';
+import { assertDocumentAttachment, inspectYText } from '../../src/utils/yjs';
 
 async function normalizedSlateDoc(sharedRoot: Y.XmlText) {
   const editor = createEditor();

--- a/packages/core/test/support/utils.ts
+++ b/packages/core/test/support/utils.ts
@@ -1,54 +1,9 @@
 import * as Y from 'yjs';
 import { Ancestor, Descendant } from 'slate';
-import { DeltaInsert } from '../../src/model/types';
-import { yTextToInsertDelta } from '../../src/utils/delta';
 import { slateNodesToInsertDelta } from '../../src';
-import { STORED_POSITION_PREFIX } from '../../src/utils/position';
-import {
-  EMPTY_TEXT_PREFIX,
-  hasEmptyTextAttribute,
-  isEmptyTextAttribute,
-} from '../../src/utils/emptyText';
-
-interface RecursiveDeltaInsert extends Omit<DeltaInsert, 'insert'> {
-  insert: string | RecursiveInsertDelta | RecursiveDeltaInsert;
-}
-
-type RecursiveInsertDelta = RecursiveDeltaInsert[];
 
 export const YJS_VERSION =
   'version' in Y && Y.version === 'oldest' ? 'oldest' : 'latest';
-
-export function inspectYText(yText: Y.XmlText): RecursiveDeltaInsert {
-  const delta = yTextToInsertDelta(yText);
-
-  const mappedDelta = delta.map(({ insert, attributes }) => {
-    if (typeof insert !== 'string') return inspectYText(insert);
-    if (!attributes) return { insert };
-
-    const filteredAttributes = Object.fromEntries(
-      Object.entries(attributes).filter(([key]) => !isEmptyTextAttribute(key))
-    );
-
-    // Do not include random empty text attribute IDs
-    if (hasEmptyTextAttribute(attributes)) {
-      filteredAttributes[`${EMPTY_TEXT_PREFIX}<id>`] = true;
-    }
-
-    return { insert, attributes: filteredAttributes };
-  });
-
-  const attributes = yText.getAttributes();
-
-  // Do not include stored position attributes
-  const filteredAttributes = Object.fromEntries(
-    Object.entries(attributes).filter(
-      ([key]) => !key.startsWith(STORED_POSITION_PREFIX)
-    )
-  );
-
-  return { attributes: filteredAttributes, insert: mappedDelta };
-}
 
 export function yTextFactory(
   ancestorOrChildren: Ancestor | Descendant[],

--- a/packages/core/test/utils/ClonedSharedRoot.test.ts
+++ b/packages/core/test/utils/ClonedSharedRoot.test.ts
@@ -1,7 +1,7 @@
 import * as Y from 'yjs';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { inspectYText } from '../support/utils';
 import { ClonedSharedRoot } from '../../src/utils/ClonedSharedRoot';
+import { inspectYText } from '../../src/utils/yjs';
 
 describe('ClonedSharedRoot', () => {
   let doc: Y.Doc;


### PR DESCRIPTION
The `inspectYText` util was previously used only for testing. It converts a `Y.XmlText` to a "recursive delta insert", a plain JS object that encodes the full nested structure of the Yjs value (with some attributes omitted or adjusted to eliminate non-determinism).

This util is useful for third-party code debugging issues with `slate-yjs`, so this PR exports it as part of `slate-yjs`'s public API.