### PR TITLE
Fix incorrect insertion location when inserting an inline element before a newly inserted empty text node

### DIFF
--- a/.changeset/frank-lies-bathe.md
+++ b/.changeset/frank-lies-bathe.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+Fix incorrect insertion location when inserting an inline element before a newly inserted empty text node

--- a/packages/core/src/applyToSlate/getInsertMethod.ts
+++ b/packages/core/src/applyToSlate/getInsertMethod.ts
@@ -1,5 +1,5 @@
 import { Editor, Node, Path, Point, Text } from 'slate';
-import { InsertDelta } from '../model/types';
+import { DeltaInsert, InsertDelta } from '../model/types';
 import { getSlateNodeYLength } from '../utils/location';
 import { deepEquals } from '../utils/object';
 import { getProperties } from '../utils/slate';
@@ -16,29 +16,34 @@ type InsertMethod =
  * Determine whether an insert delta should be performed using insertText or
  * insertNode, and at what point or path.
  */
-export function getInsertMethod(
-  editor: Editor,
-  parentPath: Path,
-  yParentDelta: InsertDelta,
-  yOffset: number,
-  attributes: Record<string, unknown>
-): InsertMethod {
+export function getInsertMethod({
+  editor,
+  parentPath,
+  yParentDelta,
+  yOffset,
+  maximumPath,
+  change: { insert, attributes = {} },
+}: {
+  editor: Editor;
+  parentPath: Path;
+  yParentDelta: InsertDelta;
+  yOffset: number;
+  maximumPath: Path | null;
+  change: DeltaInsert;
+}): InsertMethod {
   const properties = omitEmptyTextAttribute(attributes);
-  const isInsertEmptyText = hasEmptyTextAttribute(attributes);
+  const isInsertText = typeof insert === 'string';
+  const isInsertEmptyText = isInsertText && hasEmptyTextAttribute(attributes);
   const children = Array.from(Node.children(editor, parentPath));
 
   let currentOffset = 0;
-
-  const getYLength = (node: Node) =>
-    getSlateNodeYLength(node, {
-      yParentDelta,
-      yOffset: currentOffset,
-    });
 
   /**
    * Determine whether inserting into a given node using insertText is valid.
    */
   const isValidInsertionNode = (node: Node, yLength: number): boolean => {
+    if (!isInsertText) return false;
+
     // We cannot insert text into a non-text node
     if (!Text.isText(node)) return false;
 
@@ -62,7 +67,24 @@ export function getInsertMethod(
   };
 
   for (const [node, path] of children) {
-    const yLength = getYLength(node);
+    if (maximumPath && Path.isAfter(path, maximumPath)) continue;
+
+    /**
+     * If this were called on an empty text node that was previously inserted as
+     * part of the same text event, it may incorrectly report that text node's
+     * yLength as 0 even if an empty text character exists for it. This is
+     * because we use the yParentDelta prior to the text event, which does not
+     * yet contain this empty text character.
+     *
+     * To ensure that this case never arises, we use maximumPath to track the
+     * path of the most recently inserted node. Since nodes are inserted in
+     * reverse order, we should never need to insert a node past this path.
+     */
+    const yLength = getSlateNodeYLength(node, {
+      yParentDelta,
+      yOffset: currentOffset,
+    });
+
     let isFirstCandidate = false;
 
     if (currentOffset < yOffset) {
@@ -101,8 +123,9 @@ export function getInsertMethod(
        * If we reach a non-empty node after the first candidate, there are no
        * more insertion candidates, so insert just before this non-empty node.
        */
-      if (!isFirstCandidate && yLength > 0)
+      if (!isFirstCandidate && yLength > 0) {
         return { method: 'insertNode', at: path };
+      }
     }
   }
 
@@ -110,5 +133,8 @@ export function getInsertMethod(
    * None of the children were valid insertion targets, so insert after the last
    * child.
    */
-  return { method: 'insertNode', at: [...parentPath, children.length] };
+  return {
+    method: 'insertNode',
+    at: maximumPath ?? [...parentPath, children.length],
+  };
 }

--- a/packages/core/src/applyToSlate/textEvent.ts
+++ b/packages/core/src/applyToSlate/textEvent.ts
@@ -32,6 +32,8 @@ function applyDelta(
     return length;
   }, 0);
 
+  let lastInsertedPath: Path | null = null;
+
   const getTargetsInRange = (yLength: number) =>
     Array.from(
       getSlateTargetsInRange(
@@ -90,14 +92,15 @@ function applyDelta(
     }
 
     if ('insert' in change) {
-      const { insert, attributes = {} } = change;
-      const insertMethodInfo = getInsertMethod(
+      const { insert = {} } = change;
+      const insertMethodInfo = getInsertMethod({
         editor,
         parentPath,
         yParentDelta,
         yOffset,
-        attributes
-      );
+        maximumPath: lastInsertedPath,
+        change,
+      });
       const { method } = insertMethodInfo;
       let { at } = insertMethodInfo;
 
@@ -142,6 +145,15 @@ function applyDelta(
 
       const toInsert = deltaInsertToSlateNode(change);
       Transforms.insertNodes(editor, toInsert, { at });
+
+      // Determine the path of the newly inserted node
+      if (Path.isPath(at)) {
+        lastInsertedPath = at;
+      } else if (at.offset === 0) {
+        lastInsertedPath = at.path;
+      } else {
+        lastInsertedPath = Path.next(at.path);
+      }
     }
   });
 }

--- a/packages/core/test/collaboration/insertNode/afterEmptyTextNode.tsx
+++ b/packages/core/test/collaboration/insertNode/afterEmptyTextNode.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <cursor />
+    </unstyled>
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text>
+        <cursor />
+      </text>
+      <link>
+        <text />
+      </link>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export function run(editor: Editor) {
+  editor.apply({
+    type: 'insert_node',
+    path: [0, 1],
+    node: (
+      <link>
+        <text />
+      </link>
+    ),
+  });
+}

--- a/packages/core/test/collaboration/insertNode/afterLegacyEmptyTextNode.tsx
+++ b/packages/core/test/collaboration/insertNode/afterLegacyEmptyTextNode.tsx
@@ -1,0 +1,56 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+import { yTextFactory } from '../../support/utils';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <cursor />
+    </unstyled>
+  </editor>
+);
+
+export const yInput = yTextFactory(
+  <editor>
+    <unstyled />
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text />
+      <link>
+        <cursor />
+      </link>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export const yExpected = yTextFactory(
+  <editor>
+    <unstyled>
+      <text />
+      <link>
+        <text />
+      </link>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export const bidirectionalSync = true;
+
+export function run(editor: Editor) {
+  editor.apply({
+    type: 'insert_node',
+    path: [0, 1],
+    node: (
+      <link>
+        <text />
+      </link>
+    ),
+  });
+}

--- a/packages/core/test/collaboration/insertNode/beforeEmptyTextNode.tsx
+++ b/packages/core/test/collaboration/insertNode/beforeEmptyTextNode.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <cursor />
+    </unstyled>
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text />
+      <link>
+        <text />
+      </link>
+      <text>
+        <cursor />
+      </text>
+    </unstyled>
+  </editor>
+);
+
+export function run(editor: Editor) {
+  editor.apply({
+    type: 'insert_node',
+    path: [0, 0],
+    node: (
+      <link>
+        <text />
+      </link>
+    ),
+  });
+}

--- a/packages/core/test/collaboration/insertNode/beforeLegacyEmptyTextNode.tsx
+++ b/packages/core/test/collaboration/insertNode/beforeLegacyEmptyTextNode.tsx
@@ -1,0 +1,44 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../support/jsx';
+import { yTextFactory } from '../../support/utils';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <cursor />
+    </unstyled>
+  </editor>
+);
+
+export const yInput = yTextFactory(
+  <editor>
+    <unstyled />
+  </editor>
+);
+
+export const expected = (
+  <editor>
+    <unstyled>
+      <text />
+      <link>
+        <cursor />
+      </link>
+      <text />
+    </unstyled>
+  </editor>
+);
+
+export const bidirectionalSync = true;
+
+export function run(editor: Editor) {
+  editor.apply({
+    type: 'insert_node',
+    path: [0, 0],
+    node: (
+      <link>
+        <text />
+      </link>
+    ),
+  });
+}

--- a/packages/core/test/support/fixtures.ts
+++ b/packages/core/test/support/fixtures.ts
@@ -6,15 +6,66 @@ import { describe, it } from 'vitest';
 import chalk from 'chalk';
 
 export interface FixtureModule {
-  input: Editor;
-  yInput?: Y.XmlText;
-  inputStoredPositions?: Record<string, Point>;
-  initialRemoteSelection?: Range | Point;
-  expected: Editor;
-  yExpected?: Y.XmlText;
-  expectedStoredPositions?: Record<string, Point | null>;
-  expectedRemoteSelection?: Range | Point;
+  /**
+   * The transformation to perform on the local Slate editor for the purpose of
+   * the test.
+   */
   run: (e: Editor) => void;
+
+  /**
+   * The initial Slate state of the local and remote editors.
+   */
+  input: Editor;
+
+  /**
+   * The expected final Slate state of the local and remote editors.
+   */
+  expected: Editor;
+
+  /**
+   * Optionally override the initial Yjs state. By default, this is derived from
+   * the initial Slate state.
+   */
+  yInput?: Y.XmlText;
+
+  /**
+   * Optionally override the expected final Yjs state.
+   */
+  yExpected?: Y.XmlText;
+
+  /**
+   * The set of stored positions to maintain during the test. The value of each
+   * position can be asserted on using expectedStoredPositions.
+   */
+  inputStoredPositions?: Record<string, Point>;
+  expectedStoredPositions?: Record<string, Point | null>;
+
+  /**
+   * Optionally override the initial Slate selection of the remote editor. By
+   * default, the initial selection of the remote editor is null. The final
+   * remote selection can be asserted on using expectedRemoteSelection.
+   */
+  initialRemoteSelection?: Range | Point;
+  expectedRemoteSelection?: Range | Point;
+
+  /**
+   * Whether the test should also apply changes from the remote editor to the
+   * local editor, typically in the case where normalizations must be applied on
+   * the remote editor due to a Slate mismatch.
+   *
+   * This defaults to false since in most cases, a unidirectional sync should be
+   * sufficient to synchronize the local and remote editors. Generally, this
+   * should only be enabled when a Slate mismatch is expected, such as in some
+   * tests relating to legacy empty text nodes.
+   */
+  bidirectionalSync?: boolean;
+
+  /**
+   * Optionally skip a test. If a string is passed, the test will be skipped
+   * unconditionally and the given message will be displayed. If a function is
+   * passed, the test will only be skipped if that function returns a string
+   * message.
+   */
   skip?: string | (() => string | null);
 }
 

--- a/packages/core/test/support/runCollaborationTests.ts
+++ b/packages/core/test/support/runCollaborationTests.ts
@@ -32,6 +32,7 @@ async function runCollaborationTest({ module }: { module: FixtureModule }) {
     yExpected = yTextFactory(expected),
     expectedStoredPositions = {},
     expectedRemoteSelection,
+    bidirectionalSync = false,
   } = module;
 
   // Setup 'local' editor
@@ -53,6 +54,14 @@ async function runCollaborationTest({ module }: { module: FixtureModule }) {
   editor.sharedRoot.doc.on('updateV2', (update) => {
     Y.applyUpdateV2(remoteDoc, update);
   });
+
+  // If bidirectional sync is enabled, apply changes in the other direction too
+  if (bidirectionalSync) {
+    remoteDoc.on('updateV2', (update) => {
+      assertDocumentAttachment(editor.sharedRoot);
+      Y.applyUpdateV2(editor.sharedRoot.doc, update);
+    });
+  }
 
   Editor.normalize(editor, { force: true });
 

--- a/packages/core/test/utils/getInsertMethod.test.tsx
+++ b/packages/core/test/utils/getInsertMethod.test.tsx
@@ -1,126 +1,569 @@
 /** @jsx jsx */
 import { describe, it, expect } from 'vitest';
-import { Descendant, Editor } from 'slate';
+import { Editor, Node } from 'slate';
 import { jsx } from '../support/jsx';
 import { yTextFactory } from '../support/utils';
 import { yTextToInsertDelta } from '../../src/utils/delta';
 import { getInsertMethod } from '../../src/applyToSlate/getInsertMethod';
 
 describe('getInsertMethod', () => {
-  const beforeLegacyEmptyTextNodes: Descendant[] = (
-    <fragment>
-      {/* 0 */}
-      <text>one</text>
-      {/* 3 */}
-      <text>two</text>
-      {/* 6 */}
-      <text bold>three</text>
-      {/* 11 */}
-      <text />
-      {/* 12 */}
-      <text italic />
-      {/* 13 */}
-      <text italic>four</text>
-      {/* 17 */}
-      <link />
-      {/* 18 */}
-    </fragment>
-  );
+  describe('inserting text', () => {
+    describe('inserting as text into matching non-empty text nodes or legacy empty text nodes', () => {
+      it('inserts into matching non-empty text node surrounding the offset', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold>two</text>
+              <text>three</text>
+            </unstyled>
+          </editor>
+        );
 
-  const editor: Editor = (
-    <editor>
-      <unstyled>
-        {beforeLegacyEmptyTextNodes}
-        {/* 18 */}
-        <text />
-        <text />
-        <text bold />
-        <text bold />
-        {/* 18 */}
-        <link />
-        {/* 19 */}
-        <text italic />
-      </unstyled>
-    </editor>
-  );
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
 
-  const yParentDelta = yTextToInsertDelta(
-    yTextFactory(beforeLegacyEmptyTextNodes)
-  );
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'onetw'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { bold: true },
+          },
+        });
 
-  it('inserts into matching non-empty text node before offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 3, {});
-    expect(result).toEqual({
-      method: 'insertText',
-      at: { path: [0, 0], offset: 3 },
+        expect(result).toEqual({
+          method: 'insertText',
+          at: { path: [0, 1], offset: 2 },
+        });
+      });
+
+      it('inserts into matching non-empty text node before the offset', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'one'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+          },
+        });
+
+        expect(result).toEqual({
+          method: 'insertText',
+          at: { path: [0, 0], offset: 3 },
+        });
+      });
+
+      it('inserts into matching non-empty text node after the offset', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'one'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { bold: true },
+          },
+        });
+
+        expect(result).toEqual({
+          method: 'insertText',
+          at: { path: [0, 1], offset: 0 },
+        });
+      });
+
+      it('inserts into the first matching legacy empty text node at the offset', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold />
+              <text italic />
+              <text underline />
+              <text bold />
+              <text italic />
+              <text underline />
+              <text>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(
+            <fragment>
+              <text>one</text>
+              {/* No empty text nodes since they're legacy */}
+              <text>two</text>
+            </fragment>
+          )
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'one'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { underline: true },
+          },
+        });
+
+        expect(result).toEqual({
+          method: 'insertText',
+          at: { path: [0, 3], offset: 0 },
+        });
+      });
+    });
+
+    describe('inserting as node when no non-empty text nodes or legacy empty text nodes match', () => {
+      it('splits a non-matching non-empty text node surrounding the offset', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold>two</text>
+              <text>three</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'onetw'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+          },
+        });
+
+        expect(result).toEqual({
+          method: 'insertNode',
+          at: { path: [0, 1], offset: 2 },
+        });
+      });
+
+      it('inserts as node at the offset when no text nodes match', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'one'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { italic: true },
+          },
+        });
+
+        expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+      });
+
+      it('does not insert into an empty text node before the offset even if it matches', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text bold />
+              <text>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 1,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { bold: true },
+          },
+        });
+
+        expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+      });
+
+      it('does not insert into an empty text node after the offset even if it matches', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text bold>one</text>
+              <text />
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'one'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+          },
+        });
+
+        expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+      });
+
+      it('inserts as node after the last legacy empty text node if none of the matches', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text>one</text>
+              <text bold />
+              <text italic />
+              <text underline />
+              <text bold />
+              <text italic />
+              <text underline />
+              <text>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(
+            <fragment>
+              <text>one</text>
+              {/* No empty text nodes since they're legacy */}
+              <text>two</text>
+            </fragment>
+          )
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          maximumPath: null,
+          yOffset: 'one'.length,
+          change: {
+            insert: 'x',
+            attributes: { bold: true, italic: true },
+          },
+        });
+
+        expect(result).toEqual({ method: 'insertNode', at: [0, 7] });
+      });
+
+      it('inserts as node after the last node if the last node does not match', () => {
+        const editor: Editor = (
+          <editor>
+            <unstyled>
+              <text bold>one</text>
+              <text>two</text>
+            </unstyled>
+          </editor>
+        );
+
+        const yParentDelta = yTextToInsertDelta(
+          yTextFactory(Node.ancestor(editor, [0]))
+        );
+
+        const result = getInsertMethod({
+          editor,
+          parentPath: [0],
+          yParentDelta,
+          yOffset: 'onetwo'.length,
+          maximumPath: null,
+          change: {
+            insert: 'x',
+            attributes: { bold: true },
+          },
+        });
+
+        expect(result).toEqual({ method: 'insertNode', at: [0, 2] });
+      });
     });
   });
 
-  it('inserts into matching non-empty text node after offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 6, {
-      bold: true,
-    });
-    expect(result).toEqual({
-      method: 'insertText',
-      at: { path: [0, 2], offset: 0 },
-    });
-  });
+  describe('inserting an inline element', () => {
+    it('splits a non-empty text node surrounding the offset', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text>one</text>
+            <text bold>two</text>
+            <text>three</text>
+          </unstyled>
+        </editor>
+      );
 
-  it('inserts as node at offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 6, {
-      italic: true,
-    });
-    expect(result).toEqual({
-      method: 'insertNode',
-      at: [0, 2],
-    });
-  });
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(Node.ancestor(editor, [0]))
+      );
 
-  it('does not insert into matching empty text node after offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 11, {});
-    expect(result).toEqual({
-      method: 'insertNode',
-      at: [0, 3],
-    });
-  });
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 'onetw'.length,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
 
-  it('does not insert into matching empty text node before offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 13, {
-      italic: true,
+      expect(result).toEqual({
+        method: 'insertNode',
+        at: { path: [0, 1], offset: 2 },
+      });
     });
-    expect(result).toEqual({
-      method: 'insertText',
-      at: { path: [0, 5], offset: 0 },
-    });
-  });
 
-  it('inserts into first matching legacy empty text node at offset', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 18, {
-      bold: true,
-    });
-    expect(result).toEqual({
-      method: 'insertText',
-      at: { path: [0, 9], offset: 0 },
-    });
-  });
+    it('inserts between two non-empty text nodes', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text>one</text>
+            <text>two</text>
+          </unstyled>
+        </editor>
+      );
 
-  it('does not insert into non-matching legacy text node separated by non-empty text node', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 18, {
-      italic: true,
-    });
-    expect(result).toEqual({
-      method: 'insertNode',
-      at: [0, 11],
-    });
-  });
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(Node.ancestor(editor, [0]))
+      );
 
-  it('inserts after the last child', () => {
-    const result = getInsertMethod(editor, [0], yParentDelta, 19, {
-      bold: true,
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 'one'.length,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
     });
-    expect(result).toEqual({
-      method: 'insertNode',
-      at: [0, 13],
+
+    it('inserts between a non-empty and an empty text node', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text>one</text>
+            <text />
+          </unstyled>
+        </editor>
+      );
+
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(Node.ancestor(editor, [0]))
+      );
+
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 'one'.length,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+    });
+
+    it('inserts between an empty and a non-empty text node', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text />
+            <text>two</text>
+          </unstyled>
+        </editor>
+      );
+
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(Node.ancestor(editor, [0]))
+      );
+
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 1,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+    });
+
+    it('inserts between two empty text nodes', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text />
+            <text />
+          </unstyled>
+        </editor>
+      );
+
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(Node.ancestor(editor, [0]))
+      );
+
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 1,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 1] });
+    });
+
+    it('inserts after the last legacy empty text node', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text>one</text>
+            <text bold />
+            <text italic />
+            <text underline />
+            <text bold />
+            <text italic />
+            <text underline />
+            <text>two</text>
+          </unstyled>
+        </editor>
+      );
+
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(
+          <fragment>
+            <text>one</text>
+            {/* No empty text nodes since they're legacy */}
+            <text>two</text>
+          </fragment>
+        )
+      );
+
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 'one'.length,
+        maximumPath: null,
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 7] });
+    });
+
+    it('does not insert past maximumPath', () => {
+      const editor: Editor = (
+        <editor>
+          <unstyled>
+            <text>one</text>
+            <text bold />
+            <text italic />
+            <text underline />
+            <text bold />
+            <text italic />
+            <text underline />
+            <text>two</text>
+          </unstyled>
+        </editor>
+      );
+
+      const yParentDelta = yTextToInsertDelta(
+        yTextFactory(
+          <fragment>
+            <text>one</text>
+            {/* No empty text nodes since they're legacy */}
+            <text>two</text>
+          </fragment>
+        )
+      );
+
+      const result = getInsertMethod({
+        editor,
+        parentPath: [0],
+        yParentDelta,
+        yOffset: 'one'.length,
+        maximumPath: [0, 3],
+        change: {
+          insert: yTextFactory(<link>click me</link>),
+        },
+      });
+
+      expect(result).toEqual({ method: 'insertNode', at: [0, 3] });
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue that could occur when inserting both an inline element and a subsequent empty text node as part of the same Yjs text event. Due to multiple errors in the logic for determining the point or path at which a node should be inserted into Slate, the inline element could erroneously be inserted after the empty text node rather than before it.